### PR TITLE
Allowing a null query to enable conditional fetching.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "jest": "^27.0.6",
     "jest-fetch-mock": "^3.0.3",
     "microbundle": "^0.13.3",
-    "react": "16.9.0",
-    "react-dom": "16.9.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "swr": "^1.0.0",
     "ts-jest": "^27.0.5",
     "typescript": "^4.3.5"

--- a/src/hooks/useSelect.ts
+++ b/src/hooks/useSelect.ts
@@ -4,7 +4,7 @@ import useFetcher from './useFetcher';
 import { Query } from '../query';
 
 const useSelect = <Data>(
-  query: Query<Data>, swrConfig: Omit<SWRConfiguration, 'fetcher'>,
+  query: Query<Data> | null, swrConfig: Omit<SWRConfiguration, 'fetcher'>,
 ): SWRResponse<PostgrestSuccessResponse<Data>, PostgrestError> => {
   const fetcher = useFetcher<Data>('multiple');
   return useSWR(query, fetcher, swrConfig);

--- a/src/hooks/useSelectMaybeSingle.ts
+++ b/src/hooks/useSelectMaybeSingle.ts
@@ -4,7 +4,7 @@ import useFetcher from './useFetcher';
 import { Query } from '../query';
 
 const useSelectMaybeSingle = <Data>(
-  query: Query<Data>, swrConfig: Omit<SWRConfiguration, 'fetcher'>,
+  query: Query<Data> | null, swrConfig: Omit<SWRConfiguration, 'fetcher'>,
 ): SWRResponse<PostgrestSuccessResponse<Data>, PostgrestError> => {
   const fetcher = useFetcher<Data>('maybeSingle');
   return useSWR(query, fetcher, swrConfig);

--- a/src/hooks/useSelectSingle.ts
+++ b/src/hooks/useSelectSingle.ts
@@ -4,7 +4,7 @@ import { Query } from '../query';
 import useFetcher from './useFetcher';
 
 const useSelectSingle = <Data>(
-  query: Query<Data>, swrConfig: Omit<SWRConfiguration, 'fetcher'>,
+  query: Query<Data> | null, swrConfig: Omit<SWRConfiguration, 'fetcher'>,
 ): SWRResponse<PostgrestSingleSuccessResponse<Data>, PostgrestError> => {
   const fetcher = useFetcher<Data>('single');
   return useSWR(query, fetcher, swrConfig);


### PR DESCRIPTION
Added partial support for [conditional fetching](https://swr.vercel.app/docs/conditional-fetching). Only handles passing `null` and not an entire function.

Decided to add the `| null` to each of the hooks as I thought that made the code a bit more clear than just updating the `Query` type itself.

This does cause some potential weirdness when using filters with typescript. If the variable you are waiting to not be null is the variable you're filtering on (fairly common scenario I think) you would have to cast it to make TypeScript happy.

This code would fail to compile
```ts
function wrapperFunction(varName: string | null) {
  const queryName = useQuery<DraftSpecQuery>(
    "table",
    {
      columns: "foo, bar, buz",
      filter: (query) => query.eq("foo", varName),
    },
    [varName]
  );

  const { data, error, mutate } = useSelect(varName ? queryName : null, {});
}
```

and the filter would need to be changed to:
```ts
filter: (query) => query.eq("foo", varName as string),
```

Also updated React to latest 17 as that does not seem to cause any issues.